### PR TITLE
feat：support ESM

### DIFF
--- a/src/hacker.ts
+++ b/src/hacker.ts
@@ -1,18 +1,18 @@
 // overwrite uni-cli-shared utils normalizePagePath
 import { parse, resolve } from 'node:path'
 import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { customScript, isApp, inputDir as uniInputDir, platform as uniPlatform } from '@uni-helper/uni-env'
 
-// @ts-expect-error ignore
-import * as uniUtils from '@dcloudio/uni-cli-shared/dist/utils.js'
-
-// @ts-expect-error ignore
-import * as uniResolve from '@dcloudio/uni-cli-shared/dist/resolve.js'
-
-// @ts-expect-error ignore
-import * as constants from '@dcloudio/uni-cli-shared/dist/constants.js'
-
 export const platform = customScript || uniPlatform
+
+// 兼容 ESM 和 CJS 的 require
+const _require = typeof require === 'function' ? require : createRequire(import.meta.url)
+
+// 获取原始模块对象
+const uniUtils = _require('@dcloudio/uni-cli-shared/dist/utils.js')
+const uniResolve = _require('@dcloudio/uni-cli-shared/dist/resolve.js')
+const constants = _require('@dcloudio/uni-cli-shared/dist/constants.js')
 
 // 解决 MP 和 APP 平台页面文件不存在时不继续执行的问题
 // @ts-expect-error ignore


### PR DESCRIPTION
我正在处理一个关于在 `@dcloudio/vite-plugin-uni` 中支持 ESM 的问题。
https://github.com/orgs/uni-helper/discussions/10
具体来说，我们发现当使用 ESM 引入时，`vite-plugin-uni-platform` 在 ESM 环境下无法正常工作，导致报错。
是因为`hacker.ts`直接引入了一个cjs文件在esm环境下会出现错误

为了解决这个问题，我使用了 `createRequire` 方法来处理 ESM 的兼容性问题。这样，就可以在 ESM 环境中兼容原有的 CommonJS 模块引入方式。

但我不太清楚这样有什么未考虑到的风险，想让大哥如果有时间的话帮忙看看 @KeJunMao cc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved compatibility with different module systems for internal utilities, ensuring smoother operation across various environments.  
* **Chores**
  * Adjusted internal export order for consistency.  
No changes to visible features or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->